### PR TITLE
Added functionality for docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,21 +2,34 @@ version: '3.8'
 
 services:
   backend:
-    build:
-      context: ./mybackend
-    ports:
-      - "8080:8080" # hostPort:containerPort
+   # REPLACED build with image — since we now pull from ECR
+    image: 017820664528.dkr.ecr.ap-south-1.amazonaws.com/backend:latest
+
+    # ❌ REMOVED port mapping for backend — Nginx will access it internally
+    # ports:
+    #   - "8080:8080" # Exposed only in dev; NOT needed in prod. This line can be uncommented if
+    #  we want to run backend with frontend-dev in local docker compose since in frontend-dev we are running ng s not nginx reverse proxy that uses
+    # docker interned network to communicate. Best way to run is run backend and frontend-dev separately in local not on docker.
+
+    networks:
+      - app-network
 
 
-  # PROD (served by nginx). Expose on 8081 externally so it doesn't collide with dev.
+ # PROD (served by nginx). Expose on 80 for real-world access
   frontend-prod:
-    build:
-      context: ./frontend
-      dockerfile: Dockerfile
+    # REPLACED build with image — since we now pull from ECR
+    image: 017820664528.dkr.ecr.ap-south-1.amazonaws.com/frontend-prod:latest
+
+    # Keep port 80 open — this is the only public-facing service
     ports:
-      - "8081:80" # open http://localhost:8081, hostPort:containerPort - here nginx runs default at 80 in the container and we open it at 8081 in our host
-    depends_on: # starts the backend before frontend
-      - backend 
+      - "80:80" # Nginx runs inside container on 80, exposed to EC2 public 80
+
+    depends_on:
+      - backend
+
+    networks:
+      - app-network
+
 
   # DEV (Angular ng serve with hot reload)
   frontend-dev:
@@ -38,3 +51,7 @@ services:
 
 volumes:
   node_modules: {}
+
+networks:
+  app-network:
+    driver: bridge

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,19 +1,23 @@
 server {
     listen 80;
 
+    server_name _;  # Added to suppress "server_name" warning in cloud environments (wildcard)
+
+    root /usr/share/nginx/html;       # Moved here from inside location / for global use
+    index index.html;                 # Also moved for global use
+
     # Serve Angular frontend
     location / {
-        root /usr/share/nginx/html;
-        index index.html;
         try_files $uri $uri/ /index.html;
+        # Removed duplicate root + index as they're now set at server level
     }
 
     # Proxy API calls to backend
     location /api/ {
-        proxy_pass http://backend:8080;
+        proxy_pass http://backend:8080;  # ✅ No trailing slash — keeps /api prefix for Spring Boot
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection keep-alive;
+        proxy_set_header Connection 'upgrade';  # Changed from keep-alive → upgrade (more robust)
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }


### PR DESCRIPTION
1. After configuring for AWS ECR. I have added URI for private repositories of backend and frontend. Here I would be publishing the docker image for the changes made.
2. The path has :latest as the tag name that can be changed in order to create versioning like prod-5.8.1 release.
3. The port 8080 has been closed. This will ensure privacy and security groups will now only allow for port 80 (http) and 443 (https).
4. Even when the port has been removed nginx reverse proxy will be able to route requests to 8080 via Docker internal network established via docker compose. Backend is still running on 8080 just not exposed to host outside the docker container.